### PR TITLE
Fix json syntax smoke.cfg.example

### DIFF
--- a/smoke.cfg.example
+++ b/smoke.cfg.example
@@ -1,13 +1,13 @@
 {
   "secrets":"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
   "db": {
-    "dsn":"dbi:mysql:databasename
+    "dsn":"dbi:mysql:databasename",
     "user":"database user",
     "password":"database password",
     "attr": {
         "mysql_enable_utf8":1
     }
-  }
+  },
   "logpath":"/path/to/store/smokedb/log/contents",
   "post_key":"key-used-in-posting-nntp-messages-received-via-mailing-list",
   "coresmokedb_url":"https://perl5.test-smoke.org/api/",

--- a/smoke.cfg.example
+++ b/smoke.cfg.example
@@ -9,6 +9,7 @@
     }
   },
   "logpath":"/path/to/store/smokedb/log/contents",
+  "basenntp_url":"https://www.nntp.perl.org/group/perl.daily-build.reports/",
   "post_key":"key-used-in-posting-nntp-messages-received-via-mailing-list",
   "coresmokedb_url":"https://perl5.test-smoke.org/api/",
   "commits": {


### PR DESCRIPTION
Fix config file example so it can be loaded by smoke_mojo after a raw copy