### PR TITLE
Proof of concept /api/report in perl5.develop-help.com

### DIFF
--- a/mktest.jsn
+++ b/mktest.jsn
@@ -1,0 +1,79 @@
+{
+   "locale" : "",
+   "manifest_msgs" : [],
+   "out_file" : null,
+   "skip_tests" : "/home/tib/smoke/Test-Smoke/bin/smokecurrent.skiptests",
+   "summary" : "PASS",
+   "un_position" : "bottom",
+   "v" : "2",
+   "hostname" : "tib-local",
+   "cpu": "abcd",
+   "applied_patches" : [
+      "SMOKE9a9d70c38f6051857c395092b58e79353ce9f3be"
+   ],
+   "compiler_msgs" : [],
+   "sysinfo" : {
+      "git_id" : "19a540392dc1dea55a673834a3c690d1dd5dee6a",
+      "config_count" : 1,
+      "hostname" : "tib-local",
+      "cpu_description" : "11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz (GenuineIntel 2000MHz)",
+      "test_jobs" : null,
+      "smoke_date" : "2024-10-25 11:02:19 +0200",
+      "perl_id" : "5.41.6",
+      "architecture" : "x86_64",
+      "cpu_count" : "1[8 cores]",
+      "cpu": "abcd",
+      "username" : "tibo",
+      "git_describe" : "v5.41.5-21-g9a9d70c38f",
+      "osname" : "linux",
+      "duration" : 1163,
+      "smoke_perl" : "5.38.2",
+      "smoke_branch" : "blead",
+      "lc_all" : null,
+      "reporter" : "",
+      "smoker_version" : "0.047",
+      "smoke_version" : "1.82",
+      "lang" : "en_US.UTF-8",
+      "reporter_version" : "0.054",
+      "osversion" : "6.8.0-45-generic [Ubuntu 24.04.1 LTS (noble)]",
+      "user_note" : "",
+      "smoke_revision" : "1.82"
+   },
+   "un_file" : "/home/tib/smoke/Test-Smoke/bin/smokecurrent.usernote",
+   "perlio_only" : 1,
+   "rptfile" : "mktest.rpt",
+   "log_file" : null,
+   "cfg" : "/home/tib/smoke/Test-Smoke/bin/smokecurrent.buildcfg",
+   "configs" : [
+      {
+         "ccversion" : "13.2.0",
+         "cc" : "cc",
+         "debugging" : "N",
+         "arguments" : "",
+         "results" : [
+            {
+               "failures" : [],
+               "stat_tests" : "1189816",
+               "stat_cpu_time" : "649.62",
+               "statistics" : "Files=2888, Tests=1189816, 834 wallclock secs (57.02 usr  8.47 sys + 517.04 cusr 67.09 csys = 649.62 CPU",
+               "locale" : null,
+               "io_env" : "perlio",
+               "summary" : "O"
+            }
+         ],
+         "started" : "2024-10-25 11:02:19 +0200",
+         "duration" : 1163
+      }
+   ],
+   "harness3opts" : "",
+   "defaultenv" : 0,
+   "is56x" : 0,
+   "skipped_tests" : [],
+   "harness_only" : 1,
+   "ddir" : "/home/tib/smoke/Test-Smoke/perl-current",
+   "outfile" : "mktest.out",
+   "nonfatal_msgs" : [],
+   "lfile" : "/home/tib/smoke/Test-Smoke/bin/smokecurrent.log",
+   "showcfg" : 0,
+   "jsnfile" : "mktest.jsn"
+}

--- a/mktest.jsn
+++ b/mktest.jsn
@@ -3,11 +3,10 @@
    "manifest_msgs" : [],
    "out_file" : null,
    "skip_tests" : "/home/tib/smoke/Test-Smoke/bin/smokecurrent.skiptests",
-   "summary" : "PASS",
+   "summary" : "FAILED",
    "un_position" : "bottom",
    "v" : "2",
-   "hostname" : "tib-local",
-   "cpu": "abcd",
+   "hostname" : "tib-local-again",
    "applied_patches" : [
       "SMOKE9a9d70c38f6051857c395092b58e79353ce9f3be"
    ],
@@ -15,7 +14,7 @@
    "sysinfo" : {
       "git_id" : "19a540392dc1dea55a673834a3c690d1dd5dee6a",
       "config_count" : 1,
-      "hostname" : "tib-local",
+      "hostname" : "tib-local-again",
       "cpu_description" : "11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz (GenuineIntel 2000MHz)",
       "test_jobs" : null,
       "smoke_date" : "2024-10-25 11:02:19 +0200",

--- a/smokes_mojo/lib/SmokesMojo.pm
+++ b/smokes_mojo/lib/SmokesMojo.pm
@@ -45,6 +45,7 @@ sub startup ($self) {
     $r->get('/api/reports_from_id/<id:num>')->to("api#reports_from_id");
     $r->get('/api/report_data/<id:num>')->to("api#report_data");
     $r->post('/api/postreport/post')->to("api#post_report");
+    $r->post('/api/report')->to("api#post_coresmokedb_report");
     $r->get('/api/nntp_from_id/<id:num>')->to("api#nntp_from_id");
     $r->get('/api/nntp_data/<id:num>')->to("api#nntp_data");
 }

--- a/smokes_mojo/lib/SmokesMojo/Controller/Api.pm
+++ b/smokes_mojo/lib/SmokesMojo/Controller/Api.pm
@@ -2,11 +2,14 @@ package SmokesMojo::Controller::Api;
 use Mojo::Base 'Mojolicious::Controller', -signatures;
 use SmokeReports::Sensible;
 use SmokeReports::ParsedToDb "parse_report_to_db";
+use SmokeReports::ParseSmokeDB "parse_smoke_report";
 
 use Cpanel::JSON::XS;
 use IO::Uncompress::Gunzip qw(gunzip);
 use IO::Compress::Gzip qw(gzip);
 use Digest::SHA qw(sha256_hex);
+use DateTime;
+use Date::Parse qw< str2time >;
 
 sub reports_from_id ($self) {
     my $schema = $self->app->schema;
@@ -83,6 +86,56 @@ sub _fail_text ($self, $msg) {
 FAIL
 $msg
 EOS
+}
+
+sub post_coresmokedb_report ($self) {
+    my $req = $self->req;
+
+    my $schema = SmokeReports::Dbh->schema;
+    my $sdb = $schema->resultset("Perl5Smoke");
+    my $id = $sdb->get_column("report_id")->max;
+    $id = $id + 1;
+
+    my $json = Cpanel::JSON::XS->new->utf8;
+    my $report_data = $json->decode($req->body);
+    $report_data = { %{ delete $report_data->{'sysinfo'} } };
+    $report_data = { %{ delete $report_data->{'config'} } };
+    $report_data->{lc($_)} = delete $report_data->{$_} for keys %$report_data;
+    $report_data->{smoke_date} = "" . DateTime->from_epoch(
+        epoch     => str2time($report_data->{smoke_date}),
+        time_zone => 'UTC',
+    );
+
+    my @log_data = qw< log_file out_file >;
+    $report_data->{$_} = delete $report_data->{$_} for @log_data;
+
+    my @to_unarray = qw< skipped_tests applied_patches compiler_msgs manifest_msgs nonfatal_msgs >;
+    $report_data->{$_} = join("\n", @{delete($report_data->{$_}) || []}) for @to_unarray;
+
+    my @other_data = qw< harness_only harness3opts summary >;
+    $report_data->{$_} = delete $report_data->{$_} for @other_data;
+
+    my $configs = delete $report_data->{'configs'};
+
+    $report_data->{summary} = "FAILED";
+
+    my $raw = $json->encode($report_data);
+
+    my %row =
+      (
+       raw_report => $raw, #$req->body,
+       report_id => $id,
+       fetched_at => time(),
+      );
+    my $report = $sdb->create(\%row);
+
+    if ($report) {
+        parse_smoke_report($report, true);
+
+        $self->render(format => "text", text => "Created: $id");
+    } else {
+        $self->render(format => "text", text => "Error");
+    }
 }
 
 # Private API used to post NNTP reports received by mail

--- a/smokes_mojo/lib/SmokesMojo/Controller/Api.pm
+++ b/smokes_mojo/lib/SmokesMojo/Controller/Api.pm
@@ -98,9 +98,13 @@ sub post_coresmokedb_report ($self) {
 
     my $json = Cpanel::JSON::XS->new->utf8;
     my $report_data = $json->decode($req->body);
-    $report_data = { %{ delete $report_data->{'sysinfo'} } };
-    $report_data = { %{ delete $report_data->{'config'} } };
+    $report_data->{$_} = $report_data->{'sysinfo'}{$_} for keys %{ $report_data->{'sysinfo'} };
+    $report_data->{$_} = $report_data->{'config'}{$_} for keys %{ $report_data->{'config'} };
+    delete $report_data->{'sysinfo'};
+    delete $report_data->{'config'};
+
     $report_data->{lc($_)} = delete $report_data->{$_} for keys %$report_data;
+
     $report_data->{smoke_date} = "" . DateTime->from_epoch(
         epoch     => str2time($report_data->{smoke_date}),
         time_zone => 'UTC',
@@ -116,8 +120,6 @@ sub post_coresmokedb_report ($self) {
     $report_data->{$_} = delete $report_data->{$_} for @other_data;
 
     my $configs = delete $report_data->{'configs'};
-
-    $report_data->{summary} = "FAILED";
 
     my $raw = $json->encode($report_data);
 

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,2 @@
+curl -s -XPOST -H'Content-type: application/json' http://localhost:3000/api/report -d"$(cat mktest.jsn)"
+


### PR DESCRIPTION
# DO NOT MERGE

Proof of concept!

`curl -s -XPOST -H'Content-type: application/json' http://localhost:3000/api/report -d"$(cat mktest.jsn)"` will upload and insert to table `perl5_smokedb` effectively replacing the fetch `load-perl5-smokedb.pl` (coresmokedb -> perl5_smokedb)

`perl -Ilib bin/parse-smokedb` will then parse `perl5_smokedb` and insert in `parsed_reports`

Report is now available in web interface!